### PR TITLE
Dynamic Multinode Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 4. sshpass - `sudo apt-get install sshpass`
 5. A default SSH key must exist on your local platform.  If one does not exist, this can be created via the command `ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa`.
 
-NOTE:  If you encounter SSH issues running from Ubuntu, you may be hitting an issue with GNOME Keyring.  See [this article](https://chrisjean.com/ubuntu-ssh-fix-for-agent-admitted-failure-to-sign-using-the-key/) for a fix.
+NOTE:  If you encounter SSH issues running from Ubuntu, install `sudo pip install requests[security]` first.  If that does not eliminate the issue, you may be hitting an issue with GNOME Keyring.  See [this article](https://chrisjean.com/ubuntu-ssh-fix-for-agent-admitted-failure-to-sign-using-the-key/) for a fix.
 
 ### Deployment:
 Follow this procedure:

--- a/ansible/kube-master.yaml
+++ b/ansible/kube-master.yaml
@@ -7,13 +7,17 @@
   - name: Build hosts file
     lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_host }} {{item}}" state=present
     when: hostvars[item].ansible_host is defined
-    with_items: groups['all']
+    with_items: "{{ groups['all'] }}"
+
   - name: Configure EPEL release
     yum: name=epel-release state=latest
+
   - name: Install ansible
     yum: name=ansible state=latest
+
   - name: Install git
     yum: name=git state=latest
+
   - name: Install netaddr
     yum: name=python-netaddr state=latest
 
@@ -26,14 +30,9 @@
   - name: Download pub key
     fetch: src=/root/.ssh/id_rsa.pub dest=/tmp/id_rsa.tmp flat=yes
 
-  - name: Copy local key to kube-node1
-    local_action: shell cat /tmp/id_rsa.tmp | ssh root@{{ kube_node1 }} "cat >> /root/.ssh/authorized_keys"
-
-  - name: Copy local key to kube-node2
-    local_action: shell cat /tmp/id_rsa.tmp | ssh root@{{ kube_node2 }} "cat >> /root/.ssh/authorized_keys"
-
-#  - name: Copy local key to kube-master-2
-#    local_action: shell cat /tmp/id_rsa.tmp | ssh root@{{ kube_master2 }} "cat >> /root/.ssh/authorized_keys"
+  - name: Copy local key to kube-nodes
+    local_action: shell cat /tmp/id_rsa.tmp | ssh root@{{ hostvars[item].ansible_host }} "cat >> /root/.ssh/authorized_keys"
+    with_items: "{{ groups['kube-node'] }}"
 
   - name: Copy local key to kube-master
     shell: cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
@@ -57,4 +56,3 @@
     shell: chdir=/root/kubernetes/ansible /root/kubernetes/ansible/setup.sh
 
 - include: regression.yaml
-

--- a/ansible/kube-master.yaml
+++ b/ansible/kube-master.yaml
@@ -11,6 +11,12 @@
 
   - name: Configure EPEL release
     yum: name=epel-release state=latest
+    register: result
+    ignore_errors: yes
+
+  - name: Configure EPEL release (long way)
+    yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm state=present
+    when: result|failed
 
   - name: Install ansible
     yum: name=ansible state=latest

--- a/ansible/kube-node.yaml
+++ b/ansible/kube-node.yaml
@@ -5,5 +5,4 @@
   - name: Build hosts file
     lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_host }} {{item}}" state=present
     when: hostvars[item].ansible_host is defined
-    with_items: groups['all']
-
+    with_items: "{{ groups['all'] }}"

--- a/deploy-kubernetes.sh
+++ b/deploy-kubernetes.sh
@@ -117,7 +117,7 @@ function obtain_ip {
 }
 
 # From the standpoint of ansible, kube-master-2 is a 'node'
-function update_hosts_file { ##TODO##
+function update_hosts_file {
   # Update ansible hosts file
   echo Updating ansible hosts files
   echo > $HOSTS
@@ -125,25 +125,15 @@ function update_hosts_file { ##TODO##
   obtain_ip ${KUBE_MASTER_PREFIX}1
   MASTER1_IP=$IP_ADDRESS
   echo "kube-master-1 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-  #echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
 
   echo "[kube-node]" >> $HOSTS
-
+  ## Echoes in the format of "kube-node-1 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
   for(( x=1; x <= ${NUM_NODES}; x++))
   do
     obtain_ip "${KUBE_NODE_PREFIX}${x}"
     export NODE${x}_IP=$IP_ADDRESS
     echo "${KUBE_NODE_PREFIX}${x} ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
   done
-
-  #obtain_ip "${KUBE_NODE_PREFIX}1"
-  #NODE1_IP=$IP_ADDRESS
-  #echo "kube-node-1 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-  ##echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-  #obtain_ip "${KUBE_NODE_PREFIX}2"
-  #NODE2_IP=$IP_ADDRESS
-  #echo "kube-node-2 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-  ##echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
 }
 
 #Args: $1: PASSWORD, $2: IP Address
@@ -156,7 +146,7 @@ function set_ssh_key {
 }
 
 #Args: $1: master hostname $2: master IP
-function configure_master { ##TODO##
+function configure_master {
   # Get kube master password
   obtain_root_pwd $1
 
@@ -173,9 +163,7 @@ function configure_master { ##TODO##
   echo "kube-master-1" >> $INVENTORY
   echo >> $INVENTORY
   echo "[nodes]" >> $INVENTORY
-  #echo "$NODE1_IP" >> $INVENTORY
-  #echo "$NODE2_IP" >> $INVENTORY
-
+  ## Echoes in the format of "$NODE1_IP" >> $INVENTORY
   for(( x=1; x <= ${NUM_NODES}; x++))
   do
     TMP1=$(echo \${NODE${x}_IP})
@@ -191,20 +179,11 @@ function configure_master { ##TODO##
 
 }
 
-function configure_masters { ##TODO##
+function configure_masters {
   configure_master ${KUBE_MASTER_PREFIX}1 $MASTER1_IP
 
-  EXTRA_VARS=""
-  for(( x=1; x <= ${NUM_NODES}; x++))
-  do
-    TMP1=$(echo \${NODE${x}_IP})
-    LOCAL_IP=$(eval echo ${TMP1})
-    EXTRA_VARS="${EXTRA_VARS} kube_node${x}=${LOCAL_IP}"
-  done
-
   # Execute kube-master playbook
-  #ansible-playbook -i $HOSTS ansible/kube-master.yaml --extra-vars "kube_node1=$NODE1_IP kube_node2=$NODE2_IP"
-  ansible-playbook -i $HOSTS ansible/kube-master.yaml --extra-vars "${EXTRA_VARS}"
+  ansible-playbook -i $HOSTS ansible/kube-master.yaml
 }
 
 # Args $1 Node name
@@ -223,14 +202,12 @@ function configure_node {
   set_ssh_key $PASSWORD $NODE_IP
 }
 
-function configure_nodes { ##TODO##
+function configure_nodes {
   echo Configuring nodes
   for(( x=1; x <= ${NUM_NODES}; x++))
   do
     configure_node "${KUBE_NODE_PREFIX}${x}"
   done
-  #configure_node "${KUBE_NODE_PREFIX}1"
-  #configure_node "${KUBE_NODE_PREFIX}2"
 
   # Execute kube-master playbook
   ansible-playbook -i $HOSTS ansible/kube-node.yaml
@@ -241,8 +218,6 @@ function create_nodes {
   do
     create_kube "${KUBE_NODE_PREFIX}${x}"
   done
-  #create_kube "${KUBE_NODE_PREFIX}1"
-  #create_kube "${KUBE_NODE_PREFIX}2"
 }
 
 function create_masters {

--- a/deploy-kubernetes.sh
+++ b/deploy-kubernetes.sh
@@ -30,7 +30,7 @@ function get_vlan_id {
 
 # Args: $1: label $2: VLAN number
 function build_vlan_arg {
-if [ -z $2 ]; then
+  if [ -z $2 ]; then
     VLAN_ARG=""
   else
      get_vlan_id $2
@@ -40,181 +40,213 @@ if [ -z $2 ]; then
 
 # Args: $1: name
 function create_server {
-# Creates the machine
-echo "Creating $1 with $CPU cpu(s) and $MEMORY GB of RAM"
-TEMP_FILE=/tmp/create-vs.out
-build_vlan_arg "--vlan-private" $PRIVATE_VLAN
-PRIVATE_ARG=$VLAN_ARG
-build_vlan_arg "--vlan-public" $PUBLIC_VLAN
-PUBLIC_ARG=$VLAN_ARG
+  # Creates the machine
+  echo "Creating $1 with $CPU cpu(s) and $MEMORY GB of RAM"
+  TEMP_FILE=/tmp/create-vs.out
+  build_vlan_arg "--vlan-private" $PRIVATE_VLAN
+  PRIVATE_ARG=$VLAN_ARG
+  build_vlan_arg "--vlan-public" $PUBLIC_VLAN
+  PUBLIC_ARG=$VLAN_ARG
 
-echo "Deploying $SERVER_MESSAGE $1"
-yes | slcli $CLI_TYPE create --hostname $1 --domain $DOMAIN $SPEC --datacenter $DATACENTER --billing hourly  $PRIVATE_ARG $PUBLIC_ARG | tee $TEMP_FILE
+  echo "Deploying $SERVER_MESSAGE $1"
+  yes | slcli $CLI_TYPE create --hostname $1 --domain $DOMAIN $SPEC --datacenter $DATACENTER --billing hourly  $PRIVATE_ARG $PUBLIC_ARG | tee $TEMP_FILE
 }
 
 # Args: $1: name
 function get_server_id {
-# Extract virtual server ID
-slcli $CLI_TYPE list --hostname $1 --domain $DOMAIN | grep $1 > $TEMP_FILE
+  # Extract virtual server ID
+  slcli $CLI_TYPE list --hostname $1 --domain $DOMAIN | grep $1 > $TEMP_FILE
 
-# Consider only the first returned result
-VS_ID=`head -1 $TEMP_FILE | awk '{print $1}'`
+  # Consider only the first returned result
+  VS_ID=`head -1 $TEMP_FILE | awk '{print $1}'`
 }
 
 # Args: $1: name
 function create_kube {
-# Check whether kube master exists
-TEMP_FILE=/tmp/deploy-kubernetes.out
-slcli $CLI_TYPE list --hostname $1 --domain $DOMAIN | grep $1 > $TEMP_FILE
-COUNT=`wc $TEMP_FILE | awk '{print $1}'`
+  # Check whether kube master exists
+  TEMP_FILE=/tmp/deploy-kubernetes.out
+  slcli $CLI_TYPE list --hostname $1 --domain $DOMAIN | grep $1 > $TEMP_FILE
+  COUNT=`wc $TEMP_FILE | awk '{print $1}'`
 
-# Determine whether to create the kube-master
-if [ $COUNT -eq 0 ]; then
-create_server $1
-else
-echo "$1 already created"
-fi
-
-get_server_id $1
-
-# Wait kube master to be ready
-while true; do
-  echo "Waiting for $SERVER_MESSAGE $1 to be ready..."
-  STATE=`slcli $CLI_TYPE detail $VS_ID | grep state | awk '{ print $2}'`
-  if [ $STATE == 'RUNNING' ]; then
-    break
+  # Determine whether to create the kube-master
+  if [ $COUNT -eq 0 ]; then
+  create_server $1
   else
-    sleep 5
+  echo "$1 already created"
   fi
-done
+
+  get_server_id $1
+
+  # Wait kube master to be ready
+  while true; do
+    echo "Waiting for $SERVER_MESSAGE $1 to be ready..."
+    STATE=`slcli $CLI_TYPE detail $VS_ID | grep state | awk '{ print $2}'`
+    if [ $STATE == 'RUNNING' ]; then
+      break
+    else
+      sleep 5
+    fi
+  done
 }
 
 # Arg $1: hostname
 function obtain_root_pwd {
-get_server_id $1
+  get_server_id $1
 
-# Obtain the root password
-slcli $CLI_TYPE detail $VS_ID --passwords > $TEMP_FILE
+  # Obtain the root password
+  slcli $CLI_TYPE detail $VS_ID --passwords > $TEMP_FILE
 
-# Remove "remote users"
-# it seems that for Ubuntu it's print $4; however, for Mac, it's print $3
-PASSWORD=`grep root $TEMP_FILE | grep -v "remote users" | awk '{print $3}'`
-echo PASSWORD $PASSWORD
+  # Remove "remote users"
+  # it seems that for Ubuntu it's print $4; however, for Mac, it's print $3
+  PASSWORD=`grep root $TEMP_FILE | grep -v "remote users" | awk '{print $4}'`
+  echo PASSWORD $PASSWORD
 }
 
 # Args $1: hostname
 function obtain_ip {
-echo Obtaining IP address for $1
-get_server_id $1
-# Obtain the IP address
-slcli $CLI_TYPE detail $VS_ID --passwords > $TEMP_FILE
+  echo Obtaining IP address for $1
+  get_server_id $1
+  # Obtain the IP address
+  slcli $CLI_TYPE detail $VS_ID --passwords > $TEMP_FILE
 
-if [ $CONNECTION  == "VPN" ]; then
-  IP_ADDRESS=`grep private_ip $TEMP_FILE | awk '{print $2}'`
-else
-  IP_ADDRESS=`grep public_ip $TEMP_FILE | awk '{print $2}'`
-fi
+  if [ $CONNECTION  == "VPN" ]; then
+    IP_ADDRESS=`grep private_ip $TEMP_FILE | awk '{print $2}'`
+  else
+    IP_ADDRESS=`grep public_ip $TEMP_FILE | awk '{print $2}'`
+  fi
 }
 
 # From the standpoint of ansible, kube-master-2 is a 'node'
-function update_hosts_file {
-# Update ansible hosts file
-echo Updating ansible hosts files
-echo > $HOSTS
-echo "[kube-master]" >> $HOSTS
-obtain_ip ${KUBE_MASTER_PREFIX}1
-MASTER1_IP=$IP_ADDRESS
-echo "kube-master-1 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-#echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
+function update_hosts_file { ##TODO##
+  # Update ansible hosts file
+  echo Updating ansible hosts files
+  echo > $HOSTS
+  echo "[kube-master]" >> $HOSTS
+  obtain_ip ${KUBE_MASTER_PREFIX}1
+  MASTER1_IP=$IP_ADDRESS
+  echo "kube-master-1 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
+  #echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
 
-echo "[kube-node]" >> $HOSTS
-obtain_ip "${KUBE_NODE_PREFIX}1"
-NODE1_IP=$IP_ADDRESS
-echo "kube-node-1 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-#echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-obtain_ip "${KUBE_NODE_PREFIX}2"
-NODE2_IP=$IP_ADDRESS
-echo "kube-node-2 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
-#echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
+  echo "[kube-node]" >> $HOSTS
+
+  for(( x=1; x <= ${NUM_NODES}; x++))
+  do
+    obtain_ip "${KUBE_NODE_PREFIX}${x}"
+    export NODE${x}_IP=$IP_ADDRESS
+    echo "${KUBE_NODE_PREFIX}${x} ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
+  done
+
+  #obtain_ip "${KUBE_NODE_PREFIX}1"
+  #NODE1_IP=$IP_ADDRESS
+  #echo "kube-node-1 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
+  ##echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
+  #obtain_ip "${KUBE_NODE_PREFIX}2"
+  #NODE2_IP=$IP_ADDRESS
+  #echo "kube-node-2 ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
+  ##echo "$IP_ADDRESS ansible_host=$IP_ADDRESS ansible_user=root" >> $HOSTS
 }
 
 #Args: $1: PASSWORD, $2: IP Address
 function set_ssh_key {
-#Remove entry from known_hosts
-ssh-keygen -R $2
+  #Remove entry from known_hosts
+  ssh-keygen -R $2
 
-# Log in to the machine
-sshpass -p $1 ssh-copy-id -o 'StrictHostKeyChecking=no' root@$2
+  # Log in to the machine
+  sshpass -p $1 ssh-copy-id -o 'StrictHostKeyChecking=no' root@$2
 }
 
 #Args: $1: master hostname $2: master IP
-function configure_master {
-# Get kube master password
-obtain_root_pwd $1
+function configure_master { ##TODO##
+  # Get kube master password
+  obtain_root_pwd $1
 
-# Set the SSH key
-set_ssh_key $PASSWORD $2
+  # Set the SSH key
+  set_ssh_key $PASSWORD $2
 
-# Create inventory file
-INVENTORY=/tmp/inventory
-echo > $INVENTORY
-echo "[masters]" >> $INVENTORY
-echo "kube-master-1" >> $INVENTORY
-echo >> $INVENTORY
-echo "[etcd]" >> $INVENTORY
-echo "kube-master-1" >> $INVENTORY
-echo >> $INVENTORY
-echo "[nodes]" >> $INVENTORY
-echo "$NODE1_IP" >> $INVENTORY
-echo "$NODE2_IP" >> $INVENTORY
+  # Create inventory file
+  INVENTORY=/tmp/inventory
+  echo > $INVENTORY
+  echo "[masters]" >> $INVENTORY
+  echo "kube-master-1" >> $INVENTORY
+  echo >> $INVENTORY
+  echo "[etcd]" >> $INVENTORY
+  echo "kube-master-1" >> $INVENTORY
+  echo >> $INVENTORY
+  echo "[nodes]" >> $INVENTORY
+  #echo "$NODE1_IP" >> $INVENTORY
+  #echo "$NODE2_IP" >> $INVENTORY
 
-# Create ansible.cfg
-ANSIBLE_CFG=/tmp/ansible.cfg
-echo > $ANSIBLE_CFG
-echo "[defaults]" >> $ANSIBLE_CFG
-echo "host_key_checking = False" >> $ANSIBLE_CFG
+  for(( x=1; x <= ${NUM_NODES}; x++))
+  do
+    TMP1=$(echo \${NODE${x}_IP})
+    LOCAL_IP=$(eval ${TMP1})
+    echo "${LOCAL_IP}" >> ${INVENTORY}
+  done
+
+  # Create ansible.cfg
+  ANSIBLE_CFG=/tmp/ansible.cfg
+  echo > $ANSIBLE_CFG
+  echo "[defaults]" >> $ANSIBLE_CFG
+  echo "host_key_checking = False" >> $ANSIBLE_CFG
 
 }
 
-function configure_masters {
+function configure_masters { ##TODO##
   configure_master ${KUBE_MASTER_PREFIX}1 $MASTER1_IP
 
+  EXTRA_VARS=""
+  for(( x=1; x <= ${NUM_NODES}; x++))
+  do
+    TMP1=$(echo \${NODE${x}_IP})
+    LOCAL_IP=$(eval ${TMP1})
+    EXTRA_VARS += "kube_node${x}=${LOCAL_IP} "
+  done
+
   # Execute kube-master playbook
-  ansible-playbook -i $HOSTS ansible/kube-master.yaml --extra-vars "kube_node1=$NODE1_IP kube_node2=$NODE2_IP"
+  #ansible-playbook -i $HOSTS ansible/kube-master.yaml --extra-vars "kube_node1=$NODE1_IP kube_node2=$NODE2_IP"
+  ansible-playbook -i $HOSTS ansible/kube-master.yaml --extra-vars "${EXTRA_VARS}"
 }
 
 # Args $1 Node name
 function configure_node {
-echo Configuring node $1
+  echo Configuring node $1
 
-# Get kube master password
-obtain_root_pwd $1
+  # Get kube master password
+  obtain_root_pwd $1
 
-# Get master IP address
-obtain_ip $1
-NODE_IP=$IP_ADDRESS
-echo IP Address: $NODE_IP
+  # Get master IP address
+  obtain_ip $1
+  NODE_IP=$IP_ADDRESS
+  echo IP Address: $NODE_IP
 
-# Set the SSH key
-set_ssh_key $PASSWORD $NODE_IP
+  # Set the SSH key
+  set_ssh_key $PASSWORD $NODE_IP
 }
 
-function configure_nodes {
-echo Configuring nodes
-configure_node "${KUBE_NODE_PREFIX}1"
-configure_node "${KUBE_NODE_PREFIX}2"
+function configure_nodes { ##TODO##
+  echo Configuring nodes
+  for(( x=1; x <= ${NUM_NODES}; x++))
+  do
+    configure_node "${KUBE_NODE_PREFIX}${x}"
+  done
+  #configure_node "${KUBE_NODE_PREFIX}1"
+  #configure_node "${KUBE_NODE_PREFIX}2"
 
-# Execute kube-master playbook
-ansible-playbook -i $HOSTS ansible/kube-node.yaml
+  # Execute kube-master playbook
+  ansible-playbook -i $HOSTS ansible/kube-node.yaml
 }
 
 function create_nodes {
-create_kube "${KUBE_NODE_PREFIX}1"
-create_kube "${KUBE_NODE_PREFIX}2"
+  for(( x=1; x <= ${NUM_NODES}; x++))
+  do
+    create_kube "${KUBE_NODE_PREFIX}${x}"
+  done
+  #create_kube "${KUBE_NODE_PREFIX}1"
+  #create_kube "${KUBE_NODE_PREFIX}2"
 }
 
 function create_masters {
-create_kube "${KUBE_MASTER_PREFIX}1"
+  create_kube "${KUBE_MASTER_PREFIX}1"
 }
 
 # Authenticates to SL

--- a/deploy-kubernetes.sh
+++ b/deploy-kubernetes.sh
@@ -179,7 +179,7 @@ function configure_master { ##TODO##
   for(( x=1; x <= ${NUM_NODES}; x++))
   do
     TMP1=$(echo \${NODE${x}_IP})
-    LOCAL_IP=$(eval ${TMP1})
+    LOCAL_IP=$(eval echo ${TMP1})
     echo "${LOCAL_IP}" >> ${INVENTORY}
   done
 
@@ -198,8 +198,8 @@ function configure_masters { ##TODO##
   for(( x=1; x <= ${NUM_NODES}; x++))
   do
     TMP1=$(echo \${NODE${x}_IP})
-    LOCAL_IP=$(eval ${TMP1})
-    EXTRA_VARS += "kube_node${x}=${LOCAL_IP} "
+    LOCAL_IP=$(eval echo ${TMP1})
+    EXTRA_VARS="${EXTRA_VARS} kube_node${x}=${LOCAL_IP}"
   done
 
   # Execute kube-master playbook

--- a/kubernetes.cfg
+++ b/kubernetes.cfg
@@ -7,6 +7,7 @@ DOMAIN=kubernetes.casenation.com
 
 # SERVER_TYPE: bare for bare metal; anything else for virtual servers
 SERVER_TYPE=virtual
+NUM_NODES=3
 
 # CPU and memory only apply to virtual servers.
 CPU=1


### PR DESCRIPTION
Added support for specifying number of nodes in kubernetes.cfg via NUM_NODES and scripts will create that number of nodes and deploy Kubernetes on to them, instead of just a hard-coded set of 2.

Some updates to support cross-platform execution environments well.