### PR TITLE
Allow for kubeadm syntax changes and to set env for kubectl

### DIFF
--- a/ansible/kube-master.yaml
+++ b/ansible/kube-master.yaml
@@ -1,17 +1,19 @@
 ---
 - hosts: kube-master
   remote_user: root
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
   tasks:
   - include: kubelet.yaml
 
   - debug: msg="Master IP is {{ master_ip }}"
 
   - name: Initialize the master
-    shell: kubeadm init --token mymymy.kubernetes --skip-preflight-checks --api-advertise-addresses={{ master_ip }}
+    shell: kubeadm init --token mymymy.kubernetesssssss --skip-preflight-checks --apiserver-advertise-address {{ master_ip }}
     ignore_errors: yes
 
-  - name: Install Calico network
-    shell: kubectl apply -f http://docs.projectcalico.org/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+  - name: Install Calico network V2
+    shell: kubectl apply -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
 
   - name: Deploy Kube UI
     shell: kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml

--- a/ansible/kube-node.yaml
+++ b/ansible/kube-node.yaml
@@ -7,6 +7,6 @@
   - debug: msg="Master IP is {{ master_ip }}"
 
   - name: Initialize the node
-    shell: kubeadm join --token mymymy.kubernetes {{ master_ip }}  --skip-preflight-checks
+    shell: kubeadm join --token mymymy.kubernetesssssss {{ master_ip }}:6443  --skip-preflight-checks
     ignore_errors: yes
 


### PR DESCRIPTION
kube-master.yamls changes:

- The kubeadm advertise address parameter changed format from
“—api-advertise-addresses=“ to “—apiserver-advertise-address” and no
longer requires the =
- Added KUBECONFIG the the environment: at the play level to allow
later kubectl commands to function correctly
- updated the URL for the Calico installation to the V2 yaml file

kube-node.yaml changes:
- kubeadm now requires the port for join, appended “:6443” to the ip
address for the join