### PR TITLE
Update kube-master.yaml

### DIFF
--- a/ansible/kube-master.yaml
+++ b/ansible/kube-master.yaml
@@ -12,8 +12,8 @@
     shell: kubeadm init --token mymymy.kubernetesssssss --skip-preflight-checks --apiserver-advertise-address {{ master_ip }}
     ignore_errors: yes
 
-  - name: Install Calico network V2
-    shell: kubectl apply -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+  - name: Install Calico network V2.2
+    shell: kubectl apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
 
   - name: Deploy Kube UI
     shell: kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml


### PR DESCRIPTION
Calico was failing to start properly with Kubernetes 1.6.x
Reference:
http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/